### PR TITLE
Feature/scheduler job params and schedule overloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Maven:
 <dependency>
     <groupId>com.github.chrisgleissner</groupId>
     <artifactId>spring-batch-rest-api</artifactId>
-    <version>1.4.1</version>
+    <version>1.4.3</version>
 </dependency>
 ```
 
@@ -99,7 +99,7 @@ Maven:
 <dependency>
     <groupId>com.github.chrisgleissner</groupId>
     <artifactId>spring-batch-rest-quartz-api</artifactId>
-    <version>1.4.1</version>
+    <version>1.4.3</version>
 </dependency>
 ```
 

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -6,11 +6,11 @@
     <parent>
         <groupId>com.github.chrisgleissner</groupId>
         <artifactId>spring-batch-rest</artifactId>
-        <version>1.4.2-SNAPSHOT</version>
+        <version>1.4.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>spring-batch-rest-api</artifactId>
-    <version>1.4.2-SNAPSHOT</version>
+    <version>1.4.3-SNAPSHOT</version>
     <name>spring-batch-rest-api</name>
 
     <dependencies>

--- a/api/src/test/resources/application.properties
+++ b/api/src/test/resources/application.properties
@@ -2,3 +2,4 @@ spring.main.banner-mode=off
 spring.boot.admin.client.url: "http://localhost:8090"
 management.endpoints.web.exposure.include: "*"
 spring.resources.add-mappings=true
+server.port=9090

--- a/example/api/pom.xml
+++ b/example/api/pom.xml
@@ -6,11 +6,11 @@
     <parent>
         <groupId>com.github.chrisgleissner</groupId>
         <artifactId>spring-batch-rest-example</artifactId>
-        <version>1.4.2-SNAPSHOT</version>
+        <version>1.4.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>spring-batch-rest-example-core</artifactId>
-    <version>1.4.2-SNAPSHOT</version>
+    <version>1.4.3-SNAPSHOT</version>
     <name>spring-batch-rest-example-core</name>
 
     <dependencies>

--- a/example/pom.xml
+++ b/example/pom.xml
@@ -6,11 +6,11 @@
     <parent>
         <groupId>com.github.chrisgleissner</groupId>
         <artifactId>spring-batch-rest</artifactId>
-        <version>1.4.2-SNAPSHOT</version>
+        <version>1.4.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>spring-batch-rest-example</artifactId>
-    <version>1.4.2-SNAPSHOT</version>
+    <version>1.4.3-SNAPSHOT</version>
     <name>spring-batch-rest-example</name>
     <packaging>pom</packaging>
 

--- a/example/quartz-api/pom.xml
+++ b/example/quartz-api/pom.xml
@@ -6,11 +6,11 @@
     <parent>
         <groupId>com.github.chrisgleissner</groupId>
         <artifactId>spring-batch-rest-example</artifactId>
-        <version>1.4.2-SNAPSHOT</version>
+        <version>1.4.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>spring-batch-rest-example-quartz</artifactId>
-    <version>1.4.2-SNAPSHOT</version>
+    <version>1.4.3-SNAPSHOT</version>
     <name>spring-batch-rest-example-quartz</name>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -6,12 +6,12 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.2.5.RELEASE</version>
+        <version>2.2.6.RELEASE</version>
     </parent>
 
     <groupId>com.github.chrisgleissner</groupId>
     <artifactId>spring-batch-rest</artifactId>
-    <version>1.4.2-SNAPSHOT</version>
+    <version>1.4.3-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>spring-batch-rest</name>

--- a/quartz-api/pom.xml
+++ b/quartz-api/pom.xml
@@ -6,11 +6,11 @@
     <parent>
         <groupId>com.github.chrisgleissner</groupId>
         <artifactId>spring-batch-rest</artifactId>
-        <version>1.4.2-SNAPSHOT</version>
+        <version>1.4.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>spring-batch-rest-quartz-api</artifactId>
-    <version>1.4.2-SNAPSHOT</version>
+    <version>1.4.3-SNAPSHOT</version>
     <name>spring-batch-rest-quartz-api</name>
 
     <dependencies>

--- a/quartz-api/src/test/resources/application.properties
+++ b/quartz-api/src/test/resources/application.properties
@@ -2,3 +2,4 @@ spring.main.banner-mode=off
 spring.boot.admin.client.url: "http://localhost:8090"
 management.endpoints.web.exposure.include: "*"
 spring.resources.add-mappings=true
+server.port=9090

--- a/util/pom.xml
+++ b/util/pom.xml
@@ -6,11 +6,11 @@
     <parent>
         <groupId>com.github.chrisgleissner</groupId>
         <artifactId>spring-batch-rest</artifactId>
-        <version>1.4.2-SNAPSHOT</version>
+        <version>1.4.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>spring-batch-rest-util</artifactId>
-    <version>1.4.2-SNAPSHOT</version>
+    <version>1.4.3-SNAPSHOT</version>
     <name>spring-batch-rest-util</name>
 
     <dependencies>

--- a/util/src/main/java/com/github/chrisgleissner/springbatchrest/util/JobParamUtil.java
+++ b/util/src/main/java/com/github/chrisgleissner/springbatchrest/util/JobParamUtil.java
@@ -1,0 +1,34 @@
+package com.github.chrisgleissner.springbatchrest.util;
+
+import static java.util.Collections.emptyMap;
+import static java.util.stream.Collectors.toMap;
+
+import java.util.Date;
+import java.util.Map;
+import java.util.Optional;
+
+import org.springframework.batch.core.JobParameter;
+import org.springframework.batch.core.JobParameters;
+
+public class JobParamUtil {
+	
+	public static JobParameters convertRawToJobParams(Map<String, Object> properties) {
+		return new JobParameters(convertRawToParamMap(properties));
+	}
+	
+	public static Map<String, JobParameter> convertRawToParamMap(Map<String, Object> properties) {
+		return Optional.ofNullable(properties).orElse(emptyMap()).entrySet().stream()
+                .collect(toMap(Map.Entry::getKey, e -> createJobParameter(e.getValue())));
+	}
+	
+    public static JobParameter createJobParameter(Object value) {
+        if (value instanceof Date)
+            return new JobParameter((Date) value);
+        else if (value instanceof Long)
+            return new JobParameter((Long) value);
+        else if (value instanceof Double)
+            return new JobParameter((Double) value);
+        else
+            return new JobParameter("" + value);
+    }
+}

--- a/util/src/main/java/com/github/chrisgleissner/springbatchrest/util/JobParamUtil.java
+++ b/util/src/main/java/com/github/chrisgleissner/springbatchrest/util/JobParamUtil.java
@@ -11,24 +11,24 @@ import org.springframework.batch.core.JobParameter;
 import org.springframework.batch.core.JobParameters;
 
 public class JobParamUtil {
-	
+
 	public static JobParameters convertRawToJobParams(Map<String, Object> properties) {
 		return new JobParameters(convertRawToParamMap(properties));
 	}
-	
+
 	public static Map<String, JobParameter> convertRawToParamMap(Map<String, Object> properties) {
 		return Optional.ofNullable(properties).orElse(emptyMap()).entrySet().stream()
-                .collect(toMap(Map.Entry::getKey, e -> createJobParameter(e.getValue())));
+				.collect(toMap(Map.Entry::getKey, e -> createJobParameter(e.getValue())));
 	}
-	
-    public static JobParameter createJobParameter(Object value) {
-        if (value instanceof Date)
-            return new JobParameter((Date) value);
-        else if (value instanceof Long)
-            return new JobParameter((Long) value);
-        else if (value instanceof Double)
-            return new JobParameter((Double) value);
-        else
-            return new JobParameter("" + value);
-    }
+
+	public static JobParameter createJobParameter(Object value) {
+		if (value instanceof Date)
+			return new JobParameter((Date) value);
+		else if (value instanceof Long)
+			return new JobParameter((Long) value);
+		else if (value instanceof Double)
+			return new JobParameter((Double) value);
+		else
+			return new JobParameter("" + value);
+	}
 }

--- a/util/src/main/java/com/github/chrisgleissner/springbatchrest/util/TriggerUtil.java
+++ b/util/src/main/java/com/github/chrisgleissner/springbatchrest/util/TriggerUtil.java
@@ -1,0 +1,38 @@
+package com.github.chrisgleissner.springbatchrest.util;
+
+import static org.quartz.TriggerBuilder.newTrigger;
+
+import java.util.Date;
+import java.util.TimeZone;
+
+import org.quartz.CronScheduleBuilder;
+import org.quartz.Trigger;
+
+public class TriggerUtil {
+
+	// Also defined in AdHocScheduler. TODO: consider using Quartz default group.
+	private static final String GROUP_NAME = "group";
+
+	public static Trigger triggerFor(String cronExpression, String jobName, TimeZone timeZone) {
+		return triggerFor(cronExpression, jobName, timeZone, GROUP_NAME);
+	}
+
+	public static Trigger triggerFor(String cronExpression, String jobName, TimeZone timeZone, String groupName) {
+
+		CronScheduleBuilder builder = CronScheduleBuilder.cronSchedule(cronExpression);
+
+		if (timeZone != null) {
+			builder = builder.inTimeZone(timeZone);
+		}
+
+		return newTrigger().withIdentity(jobName, groupName).withSchedule(builder).forJob(jobName, groupName).build();
+	}
+
+	public static Trigger triggerFor(Date dateToRun, String jobName) {
+		return triggerFor(dateToRun, jobName, GROUP_NAME);
+	}
+
+	public static Trigger triggerFor(Date dateToRun, String jobName, String groupName) {
+		return newTrigger().withIdentity(jobName, groupName).startAt(dateToRun).forJob(jobName, groupName).build();
+	}
+}

--- a/util/src/main/java/com/github/chrisgleissner/springbatchrest/util/core/JobParamsDetail.java
+++ b/util/src/main/java/com/github/chrisgleissner/springbatchrest/util/core/JobParamsDetail.java
@@ -1,0 +1,43 @@
+package com.github.chrisgleissner.springbatchrest.util.core;
+
+import java.util.Map;
+
+import org.quartz.JobDetail;
+import org.quartz.JobKey;
+import org.quartz.impl.JobDetailImpl;
+import org.quartz.utils.Key;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+/**
+ * Extension class to add JobParameters to a JobDetail for scheduled execution with JobParameters.
+ * @author theJeff77
+ */
+
+@Data
+@EqualsAndHashCode(callSuper = false)
+public class JobParamsDetail extends JobDetailImpl {
+	
+	private static final long serialVersionUID = -4813776846767160965L;
+	private Map<String, Object> rawJobParameters;
+	
+	public JobParamsDetail(JobDetail jobDetail) {
+        
+        this.setJobClass(jobDetail.getJobClass());
+        this.setDescription(jobDetail.getDescription());
+        if(jobDetail.getKey() == null)
+            this.setKey(new JobKey(Key.createUniqueName(null), null));
+        this.setKey(jobDetail.getKey()); 
+        this.setDurability(jobDetail.isDurable());
+        this.setRequestsRecovery(jobDetail.requestsRecovery());
+        
+        if(!jobDetail.getJobDataMap().isEmpty())
+            this.setJobDataMap(jobDetail.getJobDataMap());
+	}
+	
+	public JobParamsDetail(JobDetail jobDetail, Map<String, Object> rawJobParameters) {
+		this(jobDetail);
+		this.rawJobParameters = rawJobParameters;
+	}
+}

--- a/util/src/main/java/com/github/chrisgleissner/springbatchrest/util/core/JobParamsDetail.java
+++ b/util/src/main/java/com/github/chrisgleissner/springbatchrest/util/core/JobParamsDetail.java
@@ -11,31 +11,33 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 
 /**
- * Extension class to add JobParameters to a JobDetail for scheduled execution with JobParameters.
+ * Extension class to add JobParameters to a JobDetail for scheduled execution
+ * with JobParameters.
+ * 
  * @author theJeff77
  */
 
 @Data
 @EqualsAndHashCode(callSuper = false)
 public class JobParamsDetail extends JobDetailImpl {
-	
+
 	private static final long serialVersionUID = -4813776846767160965L;
 	private Map<String, Object> rawJobParameters;
-	
+
 	public JobParamsDetail(JobDetail jobDetail) {
-        
-        this.setJobClass(jobDetail.getJobClass());
-        this.setDescription(jobDetail.getDescription());
-        if(jobDetail.getKey() == null)
-            this.setKey(new JobKey(Key.createUniqueName(null), null));
-        this.setKey(jobDetail.getKey()); 
-        this.setDurability(jobDetail.isDurable());
-        this.setRequestsRecovery(jobDetail.requestsRecovery());
-        
-        if(!jobDetail.getJobDataMap().isEmpty())
-            this.setJobDataMap(jobDetail.getJobDataMap());
+
+		this.setJobClass(jobDetail.getJobClass());
+		this.setDescription(jobDetail.getDescription());
+		if (jobDetail.getKey() == null)
+			this.setKey(new JobKey(Key.createUniqueName(null), null));
+		this.setKey(jobDetail.getKey());
+		this.setDurability(jobDetail.isDurable());
+		this.setRequestsRecovery(jobDetail.requestsRecovery());
+
+		if (!jobDetail.getJobDataMap().isEmpty())
+			this.setJobDataMap(jobDetail.getJobDataMap());
 	}
-	
+
 	public JobParamsDetail(JobDetail jobDetail, Map<String, Object> rawJobParameters) {
 		this(jobDetail);
 		this.rawJobParameters = rawJobParameters;

--- a/util/src/main/java/com/github/chrisgleissner/springbatchrest/util/quartz/AdHocScheduler.java
+++ b/util/src/main/java/com/github/chrisgleissner/springbatchrest/util/quartz/AdHocScheduler.java
@@ -8,6 +8,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.quartz.JobDetail;
 import org.quartz.Scheduler;
 import org.quartz.Trigger;
+import org.quartz.TriggerKey;
 import org.springframework.batch.core.Job;
 import org.springframework.batch.core.configuration.annotation.JobBuilderFactory;
 import org.springframework.batch.core.configuration.annotation.StepBuilderFactory;
@@ -200,7 +201,7 @@ public class AdHocScheduler {
     
     private JobDetail jobDetailFor(JobConfig jobConfig) {
         JobDetail jobDetail = newJob(QuartzJobLauncher.class)
-                .withIdentity(jobConfig.getName(), GROUP_NAME)
+                .withIdentity(jobConfig.getName())
                 .usingJobData(QuartzJobLauncher.JOB_NAME, jobConfig.getName())
                 .build();
         
@@ -216,7 +217,7 @@ public class AdHocScheduler {
     
     private Trigger triggerFor(String cronExpression, String jobName, TimeZone timeZone, String groupName) {
         return newTrigger()
-                .withIdentity(jobName + "-trigger", groupName)
+                .withIdentity(this.getTriggerKey(jobName, groupName))
                 .withSchedule(CronScheduleBuilder
                         .cronSchedule(cronExpression)
                         .inTimeZone(timeZone))
@@ -230,9 +231,13 @@ public class AdHocScheduler {
     
     private Trigger triggerFor(Date dateToRun, String jobName, String groupName) {
         return newTrigger()
-        		.withIdentity(jobName + "-trigger", groupName)
+        		.withIdentity(this.getTriggerKey(jobName, groupName))
         		.startAt(dateToRun)
         		.forJob(jobName)
         		.build();
+    }
+    
+    private TriggerKey getTriggerKey(String jobName, String groupName) {
+    	return new TriggerKey(jobName + "-trigger", groupName);
     }
 }

--- a/util/src/main/java/com/github/chrisgleissner/springbatchrest/util/quartz/AdHocScheduler.java
+++ b/util/src/main/java/com/github/chrisgleissner/springbatchrest/util/quartz/AdHocScheduler.java
@@ -1,5 +1,6 @@
 package com.github.chrisgleissner.springbatchrest.util.quartz;
 
+import com.github.chrisgleissner.springbatchrest.util.TriggerUtil;
 import com.github.chrisgleissner.springbatchrest.util.core.JobBuilder;
 import com.github.chrisgleissner.springbatchrest.util.core.JobConfig;
 import com.github.chrisgleissner.springbatchrest.util.core.JobParamsDetail;
@@ -16,228 +17,200 @@ import org.springframework.stereotype.Component;
 
 import static java.lang.String.format;
 import static org.quartz.JobBuilder.newJob;
-import static org.quartz.TriggerBuilder.newTrigger;
 
 import java.util.Date;
 import java.util.TimeZone;
 
-import org.quartz.CronScheduleBuilder;
-
 /**
- * Allows to schedule Spring Batch jobs via Quartz by using a {@link #schedule(String, Job, String)} method
- * rather than Spring wiring each job. This allows for programmatic creation of multiple jobs at run-time.
+ * Allows to schedule Spring Batch jobs via Quartz by using a
+ * {@link #schedule(String, Job, String)} method rather than Spring wiring each
+ * job. This allows for programmatic creation of multiple jobs at run-time.
  */
 @Slf4j
 @Component
 public class AdHocScheduler {
-    private static final String GROUP_NAME = "group";
+	private static final String GROUP_NAME = "group";
 
-    private final JobBuilder jobBuilder;
-    private Scheduler scheduler;
-    private JobBuilderFactory jobBuilderFactory;
-    private StepBuilderFactory stepBuilderFactory;
+	private final JobBuilder jobBuilder;
+	private Scheduler scheduler;
+	private JobBuilderFactory jobBuilderFactory;
+	private StepBuilderFactory stepBuilderFactory;
 
-    @Autowired
-    public AdHocScheduler(JobBuilder jobBuilder, Scheduler scheduler, JobBuilderFactory jobBuilderFactory, StepBuilderFactory stepBuilderFactory) {
-        this.jobBuilder = jobBuilder;
-        this.scheduler = scheduler;
-        this.jobBuilderFactory = jobBuilderFactory;
-        this.stepBuilderFactory = stepBuilderFactory;
-    }
+	@Autowired
+	public AdHocScheduler(JobBuilder jobBuilder, Scheduler scheduler, JobBuilderFactory jobBuilderFactory,
+			StepBuilderFactory stepBuilderFactory) {
+		this.jobBuilder = jobBuilder;
+		this.scheduler = scheduler;
+		this.jobBuilderFactory = jobBuilderFactory;
+		this.stepBuilderFactory = stepBuilderFactory;
+	}
 
-    /**
-     * Schedules a Spring Batch job via a Quartz cron expression.
-     * Job referenced via jobConfig's name must be a valid registered bean name for a Job object.
-     */
-    public synchronized void schedule(JobConfig jobConfig, Date dateToRun) {
-        log.debug("Scheduling job {} with custom Trigger", jobConfig.getName());
-        try {
-            JobDetail jobDetail = this.jobDetailFor(jobConfig);
-            Trigger trigger = this.triggerFor(dateToRun, jobConfig.getName());
-            scheduler.unscheduleJob(trigger.getKey());
-            scheduler.scheduleJob(jobDetail, trigger);
-            log.info("Scheduled job {} with Date {}", jobConfig.getName(), dateToRun.toString());
-        } catch (Exception e) {
-            throw new RuntimeException(format("Can't schedule job %s with date: %s", jobConfig.getName(), dateToRun.toString()), e);
-        }
-    }
-    
-    /**
-     * Schedules a Spring Batch job via a Quartz cron expression. Uses the job name of the provided job.
-     */
-    public synchronized Job schedule(Job job, String cronExpression) {
-    	return this.schedule(job.getName(), job, cronExpression, null);
-    }
-    
-    /**
-     * Schedules a Spring Batch job via a Quartz cron expression. Uses the job name of the provided job.
-     */
-    public synchronized Job schedule(Job job, String cronExpression, TimeZone timeZone) {
-    	return this.schedule(job.getName(), job, cronExpression, timeZone);
-    }
-    
-    /**
-     * Schedules a Spring Batch job via a Quartz cron expression.
-     * Also registers the job with the specified jobName, rather than the job param's name
-     */
-    public synchronized Job schedule(String jobName, Job job, String cronExpression) {
-    	return this.schedule(jobName, job, cronExpression, null);
-    }
-    
-    /**
-     * Schedules a Spring Batch job via a Quartz cron expression.
-     * Also registers the job with the specified jobName, rather than the job param's name
-     */
-    public synchronized Job schedule(String jobName, Job job, String cronExpression, TimeZone timeZone) {
-        log.debug("Scheduling job {} with CRON expression {}", jobName, cronExpression);
-        try {
-            jobBuilder.registerJob(job);
-            JobDetail jobDetail = this.jobDetailFor(jobName);
+	/**
+	 * Schedules a Spring Batch job via a Quartz cron expression. Job referenced via
+	 * jobConfig's name must be a valid registered bean name for a Job object.
+	 */
+	public synchronized void schedule(JobConfig jobConfig, Date dateToRun) {
+		log.debug("Scheduling job {} with custom Trigger", jobConfig.getName());
+		try {
+			JobDetail jobDetail = this.jobDetailFor(jobConfig);
+			Trigger trigger = TriggerUtil.triggerFor(dateToRun, jobConfig.getName());
+			scheduler.unscheduleJob(trigger.getKey());
+			scheduler.scheduleJob(jobDetail, trigger);
+			log.info("Scheduled job {} with Date {}", jobConfig.getName(), dateToRun.toString());
+		} catch (Exception e) {
+			throw new RuntimeException(
+					format("Can't schedule job %s with date: %s", jobConfig.getName(), dateToRun.toString()), e);
+		}
+	}
 
-            Trigger trigger = this.triggerFor(cronExpression, jobName, timeZone);
+	/**
+	 * Schedules a Spring Batch job via a Quartz cron expression. Uses the job name
+	 * of the provided job.
+	 */
+	public synchronized Job schedule(Job job, String cronExpression) {
+		return this.schedule(job.getName(), job, cronExpression, null);
+	}
 
-            scheduler.unscheduleJob(trigger.getKey());
-            scheduler.scheduleJob(jobDetail, trigger);
-            log.info("Scheduled job {} with CRON expression {}", jobName, cronExpression);
-        } catch (Exception e) {
-            throw new RuntimeException(format("Can't schedule job %s with cronExpression %s", jobName, cronExpression), e);
-        }
-        return job;
-    }
-    
-    /**
-     * Schedules a Spring Batch job via a Quartz cron expression.
-     * Job referenced via jobConfig's name must be a valid registered bean name for a Job object.
-     */
-    public synchronized void schedule(JobConfig jobConfig, String cronExpression) {
-    	this.schedule(jobConfig, cronExpression, null);
-    }
-    
-    /**
-     * Schedules a Spring Batch job via a Quartz cron expression.
-     */
-    public synchronized void schedule(JobConfig jobConfig, String cronExpression, TimeZone timeZone) {
-        log.debug("Scheduling job {} with CRON expression {}", jobConfig.getName(), cronExpression);
-        try {
-            JobDetail jobDetail = this.jobDetailFor(jobConfig);
+	/**
+	 * Schedules a Spring Batch job via a Quartz cron expression. Uses the job name
+	 * of the provided job.
+	 */
+	public synchronized Job schedule(Job job, String cronExpression, TimeZone timeZone) {
+		return this.schedule(job.getName(), job, cronExpression, timeZone);
+	}
 
-            Trigger trigger = this.triggerFor(cronExpression, jobConfig.getName(), timeZone);
+	/**
+	 * Schedules a Spring Batch job via a Quartz cron expression. Also registers the
+	 * job with the specified jobName, rather than the job param's name
+	 */
+	public synchronized Job schedule(String jobName, Job job, String cronExpression) {
+		return this.schedule(jobName, job, cronExpression, null);
+	}
 
-            scheduler.unscheduleJob(trigger.getKey());
-            scheduler.scheduleJob(jobDetail, trigger);
-            log.info("Scheduled job {} with CRON expression {}", jobConfig.getName(), cronExpression);
-        } catch (Exception e) {
-            throw new RuntimeException(format("Can't schedule job %s with cronExpression %s", jobConfig.getName(), cronExpression), e);
-        }
-    }
+	/**
+	 * Schedules a Spring Batch job via a Quartz cron expression. Also registers the
+	 * job with the specified jobName, rather than the job param's name
+	 */
+	public synchronized Job schedule(String jobName, Job job, String cronExpression, TimeZone timeZone) {
+		log.debug("Scheduling job {} with CRON expression {}", jobName, cronExpression);
+		try {
+			jobBuilder.registerJob(job);
+			JobDetail jobDetail = this.jobDetailFor(jobName);
 
-    /**
-     * Starts the Quartz scheduler unless it is already started. Necessary for any scheduled jobs to start.
-     */
-    public synchronized void start() {
-        try {
-            if (!scheduler.isStarted()) {
-                scheduler.start();
-                log.info("Started Quartz scheduler");
-            } else {
-                log.warn("Quartz scheduler already started");
-            }
-        } catch (Exception e) {
-            throw new RuntimeException("Could not start Quartz scheduler", e);
-        }
-    }
+			Trigger trigger = TriggerUtil.triggerFor(cronExpression, jobName, timeZone);
 
-    public synchronized void pause() {
-        try {
-            if (scheduler.isStarted() && !scheduler.isInStandbyMode()) {
-                scheduler.pauseAll();
-                log.info("Paused Quartz scheduler");
-            }
-        } catch (Exception e) {
-            throw new RuntimeException("Could not pause Quartz scheduler", e);
-        }
-    }
+			scheduler.unscheduleJob(trigger.getKey());
+			scheduler.scheduleJob(jobDetail, trigger);
+			log.info("Scheduled job {} with CRON expression {}", jobName, cronExpression);
+		} catch (Exception e) {
+			throw new RuntimeException(format("Can't schedule job %s with cronExpression %s", jobName, cronExpression),
+					e);
+		}
+		return job;
+	}
 
-    public synchronized void resume() {
-        try {
-            if (scheduler.isStarted() && scheduler.isInStandbyMode()) {
-                scheduler.resumeAll();
-                log.info("Resumed Quartz scheduler");
-            }
-        } catch (Exception e) {
-            throw new RuntimeException("Could not resumse Quartz scheduler", e);
-        }
-    }
+	/**
+	 * Schedules a Spring Batch job via a Quartz cron expression. Job referenced via
+	 * jobConfig's name must be a valid registered bean name for a Job object.
+	 */
+	public synchronized void schedule(JobConfig jobConfig, String cronExpression) {
+		this.schedule(jobConfig, cronExpression, null);
+	}
 
-    public synchronized void stop() {
-        try {
-            if (scheduler.isStarted() && !scheduler.isShutdown()) {
-                scheduler.shutdown();
-                log.info("Stopped Quartz scheduler");
-            }
-        } catch (Exception e) {
-            throw new RuntimeException("Could not stop Quartz scheduler", e);
-        }
-    }
+	/**
+	 * Schedules a Spring Batch job via a Quartz cron expression.
+	 */
+	public synchronized void schedule(JobConfig jobConfig, String cronExpression, TimeZone timeZone) {
+		log.debug("Scheduling job {} with CRON expression {}", jobConfig.getName(), cronExpression);
+		try {
+			JobDetail jobDetail = this.jobDetailFor(jobConfig);
 
-    public JobBuilderFactory jobs() {
-        return jobBuilderFactory;
-    }
+			Trigger trigger = TriggerUtil.triggerFor(cronExpression, jobConfig.getName(), timeZone);
 
-    public StepBuilderFactory steps() {
-        return stepBuilderFactory;
-    }
-    
-    // ===============
-    // Private Helpers
-    // ===============
-    
-    private JobDetail jobDetailFor(String jobName) {
-        JobConfig config = new JobConfig();
-        config.setName(jobName);
-        return this.jobDetailFor(config);
-    }
-    
-    private JobDetail jobDetailFor(JobConfig jobConfig) {
-        JobDetail jobDetail = newJob(QuartzJobLauncher.class)
-                .withIdentity(jobConfig.getName(), GROUP_NAME)
-                .usingJobData(QuartzJobLauncher.JOB_NAME, jobConfig.getName())
-                .build();
-        
-        if (jobConfig.getProperties() != null) {
-        	jobDetail = new JobParamsDetail(jobDetail, jobConfig.getProperties());
-        }
-        return jobDetail;
-    }
-    
-    private Trigger triggerFor(String cronExpression, String jobName, TimeZone timeZone) {
-    	return triggerFor(cronExpression, jobName, timeZone, GROUP_NAME);
-    }
-    
-    private Trigger triggerFor(String cronExpression, String jobName, TimeZone timeZone, String groupName) {
-    	
-    	CronScheduleBuilder builder = CronScheduleBuilder.cronSchedule(cronExpression);
-    	
-    	if (timeZone != null) {
-    		builder.inTimeZone(timeZone);
-    	}
-    	
-        return newTrigger()
-                .withIdentity(jobName, groupName)
-                .withSchedule(builder)
-                .forJob(jobName, groupName)
-                .build();
-    }
-    
-    private Trigger triggerFor(Date dateToRun, String jobName) {
-    	return this.triggerFor(dateToRun, jobName, GROUP_NAME);
-    }
-    
-    private Trigger triggerFor(Date dateToRun, String jobName, String groupName) {
-        return newTrigger()
-        		.withIdentity(jobName, groupName)
-        		.startAt(dateToRun)
-        		.forJob(jobName, groupName)
-        		.build();
-    }
+			scheduler.unscheduleJob(trigger.getKey());
+			scheduler.scheduleJob(jobDetail, trigger);
+			log.info("Scheduled job {} with CRON expression {}", jobConfig.getName(), cronExpression);
+		} catch (Exception e) {
+			throw new RuntimeException(
+					format("Can't schedule job %s with cronExpression %s", jobConfig.getName(), cronExpression), e);
+		}
+	}
+
+	/**
+	 * Starts the Quartz scheduler unless it is already started. Necessary for any
+	 * scheduled jobs to start.
+	 */
+	public synchronized void start() {
+		try {
+			if (!scheduler.isStarted()) {
+				scheduler.start();
+				log.info("Started Quartz scheduler");
+			} else {
+				log.warn("Quartz scheduler already started");
+			}
+		} catch (Exception e) {
+			throw new RuntimeException("Could not start Quartz scheduler", e);
+		}
+	}
+
+	public synchronized void pause() {
+		try {
+			if (scheduler.isStarted() && !scheduler.isInStandbyMode()) {
+				scheduler.pauseAll();
+				log.info("Paused Quartz scheduler");
+			}
+		} catch (Exception e) {
+			throw new RuntimeException("Could not pause Quartz scheduler", e);
+		}
+	}
+
+	public synchronized void resume() {
+		try {
+			if (scheduler.isStarted() && scheduler.isInStandbyMode()) {
+				scheduler.resumeAll();
+				log.info("Resumed Quartz scheduler");
+			}
+		} catch (Exception e) {
+			throw new RuntimeException("Could not resumse Quartz scheduler", e);
+		}
+	}
+
+	public synchronized void stop() {
+		try {
+			if (scheduler.isStarted() && !scheduler.isShutdown()) {
+				scheduler.shutdown();
+				log.info("Stopped Quartz scheduler");
+			}
+		} catch (Exception e) {
+			throw new RuntimeException("Could not stop Quartz scheduler", e);
+		}
+	}
+
+	public JobBuilderFactory jobs() {
+		return jobBuilderFactory;
+	}
+
+	public StepBuilderFactory steps() {
+		return stepBuilderFactory;
+	}
+
+	// ===============
+	// Private Helpers
+	// ===============
+
+	private JobDetail jobDetailFor(String jobName) {
+		JobConfig config = new JobConfig();
+		config.setName(jobName);
+		return this.jobDetailFor(config);
+	}
+
+	private JobDetail jobDetailFor(JobConfig jobConfig) {
+		JobDetail jobDetail = newJob(QuartzJobLauncher.class).withIdentity(jobConfig.getName(), GROUP_NAME)
+				.usingJobData(QuartzJobLauncher.JOB_NAME, jobConfig.getName()).build();
+
+		if (jobConfig.getProperties() != null) {
+			jobDetail = new JobParamsDetail(jobDetail, jobConfig.getProperties());
+		}
+		return jobDetail;
+	}
 }

--- a/util/src/main/java/com/github/chrisgleissner/springbatchrest/util/quartz/QuartzJobLauncher.java
+++ b/util/src/main/java/com/github/chrisgleissner/springbatchrest/util/quartz/QuartzJobLauncher.java
@@ -2,6 +2,7 @@ package com.github.chrisgleissner.springbatchrest.util.quartz;
 
 import lombok.extern.slf4j.Slf4j;
 import org.quartz.JobDataMap;
+import org.quartz.JobDetail;
 import org.quartz.JobExecutionContext;
 import org.springframework.batch.core.Job;
 import org.springframework.batch.core.JobExecution;
@@ -9,6 +10,9 @@ import org.springframework.batch.core.JobParameters;
 import org.springframework.batch.core.configuration.JobLocator;
 import org.springframework.batch.core.launch.JobLauncher;
 import org.springframework.scheduling.quartz.QuartzJobBean;
+
+import com.github.chrisgleissner.springbatchrest.util.JobParamUtil;
+import com.github.chrisgleissner.springbatchrest.util.core.JobParamsDetail;
 
 @Slf4j
 public class QuartzJobLauncher extends QuartzJobBean {
@@ -21,6 +25,13 @@ public class QuartzJobLauncher extends QuartzJobBean {
     protected void executeInternal(JobExecutionContext context) {
         String jobName = null;
         try {
+        	
+        	JobDetail jobDetail = context.getJobDetail();
+        	JobParameters jobParams = new JobParameters();
+        	if (jobDetail instanceof JobParamsDetail) {
+        		jobParams = JobParamUtil.convertRawToJobParams(((JobParamsDetail)jobDetail).getRawJobParameters());
+        	}
+        	
             JobDataMap dataMap = context.getJobDetail().getJobDataMap();
             jobName = dataMap.getString(JOB_NAME);
 
@@ -29,7 +40,7 @@ public class QuartzJobLauncher extends QuartzJobBean {
 
             Job job = jobLocator.getJob(jobName);
             log.info("Starting {}", job.getName());
-            JobExecution jobExecution = jobLauncher.run(job, new JobParameters());
+            JobExecution jobExecution = jobLauncher.run(job, jobParams);
             log.info("{}_{} was completed successfully", job.getName(), jobExecution.getId());
         } catch (Exception e) {
             log.error("Job {} failed", jobName, e);

--- a/util/src/test/java/com/github/chrisgleissner/springbatchrest/util/core/AdHocStarterTest.java
+++ b/util/src/test/java/com/github/chrisgleissner/springbatchrest/util/core/AdHocStarterTest.java
@@ -3,8 +3,6 @@ package com.github.chrisgleissner.springbatchrest.util.core;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.junit.jupiter.MockitoSettings;
-import org.mockito.quality.Strictness;
 import org.springframework.batch.core.Job;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
@@ -53,7 +51,7 @@ public class AdHocStarterTest {
                 propMap.put("foo", propertyValue++);
                 starter.start(jobToRun, true, propMap);
             }
-            assertThat(latch.await(2, SECONDS)).isTrue();
+            assertThat(latch.await(4, SECONDS)).isTrue();
             assertThat(propertyValues).hasSize(propertyValue);
         }
         Thread.sleep(100); // Job completion takes place after latch is counted down
@@ -86,7 +84,7 @@ public class AdHocStarterTest {
                         .property("foo", "" + propertyValue++)
                         .asynchronous(true).build());
             }
-            assertThat(latch.await(2, SECONDS)).isTrue();
+            assertThat(latch.await(4, SECONDS)).isTrue();
             assertThat(propertyValues).hasSize(propertyValue);
         }
         Thread.sleep(100); // Job completion takes place after latch is counted down

--- a/util/src/test/java/com/github/chrisgleissner/springbatchrest/util/quartz/AdHocSchedulerTest.java
+++ b/util/src/test/java/com/github/chrisgleissner/springbatchrest/util/quartz/AdHocSchedulerTest.java
@@ -1,6 +1,8 @@
 package com.github.chrisgleissner.springbatchrest.util.quartz;
 
 import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.runner.RunWith;
 import org.springframework.batch.core.Job;
 import org.springframework.batch.core.launch.support.RunIdIncrementer;
@@ -9,43 +11,106 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
 
+import com.github.chrisgleissner.springbatchrest.util.core.JobBuilder;
+import com.github.chrisgleissner.springbatchrest.util.core.JobConfig;
+
 import java.util.concurrent.CountDownLatch;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
 
+import java.time.Instant;
+import java.util.Date;
+
 /**
- * Tests the ad-hoc Quartz scheduling of Spring Batch jobs, allowing for programmatic scheduling after Spring wiring.
+ * Tests the ad-hoc Quartz scheduling of Spring Batch jobs, allowing for
+ * programmatic scheduling after Spring wiring.
  */
 @RunWith(SpringRunner.class)
 @ContextConfiguration(classes = AdHocSchedulerConfig.class)
 public class AdHocSchedulerTest {
 
-    private static final String TRIGGER_EVERY_SECOND = "0/1 * * * * ?";
-    private static final int NUMBER_OF_EXECUTIONS_PER_JOB = 2;
+	private static final String TRIGGER_EVERY_SECOND = "0/1 * * * * ?";
+	private static final int NUMBER_OF_EXECUTIONS_PER_JOB = 2;
 
-    @Autowired
-    private AdHocScheduler scheduler;
+	@Autowired
+	private AdHocScheduler scheduler;
 
-    private CountDownLatch latch1 = new CountDownLatch(NUMBER_OF_EXECUTIONS_PER_JOB);
-    private CountDownLatch latch2 = new CountDownLatch(NUMBER_OF_EXECUTIONS_PER_JOB);
+	@Autowired
+	private JobBuilder jobBuilder;
 
-    @Test
-    public void scheduleWorks() throws InterruptedException {
-        scheduler.schedule("j1", job("j1", latch1), TRIGGER_EVERY_SECOND);
-        scheduler.schedule("j2", job("j2", latch2), TRIGGER_EVERY_SECOND);
-        scheduler.start();
+	private CountDownLatch latch1 = new CountDownLatch(NUMBER_OF_EXECUTIONS_PER_JOB);
+	private CountDownLatch latch2 = new CountDownLatch(NUMBER_OF_EXECUTIONS_PER_JOB);
 
-        latch1.await(4, SECONDS);
-        latch2.await(4, SECONDS);
-        scheduler.stop();
-    }
+	@BeforeEach
+	public void before() {
+		latch1 = new CountDownLatch(NUMBER_OF_EXECUTIONS_PER_JOB);
+		latch2 = new CountDownLatch(NUMBER_OF_EXECUTIONS_PER_JOB);
+	}
 
-    private Job job(String jobName, CountDownLatch latch) {
-        return scheduler.jobs().get(jobName)
-                .incrementer(new RunIdIncrementer()) // adds unique parameter on each run so that createJob can be rerun
-                .start(scheduler.steps().get("step").tasklet((contribution, chunkContext) -> {
-                    latch.countDown();
-                    return RepeatStatus.FINISHED;
-                }).allowStartIfComplete(true).build()).build();
-    }
+	@AfterAll
+	public void afterAll() {
+		scheduler.stop();
+	}
+
+	@Test
+	public void scheduleCronWithJobReferenceWorks() throws InterruptedException {
+		scheduler.schedule("j1", job("j1", latch1), TRIGGER_EVERY_SECOND);
+		scheduler.schedule("j2", job("j2", latch2), TRIGGER_EVERY_SECOND);
+		scheduler.start();
+
+		latch1.await(4, SECONDS);
+		latch2.await(4, SECONDS);
+		scheduler.pause();
+	}
+
+	@Test
+	public void scheduleWithJobConfigAndDateWorks() throws InterruptedException {
+		Job job1 = job("j1", latch1);
+		Job job2 = job("j2", latch2);
+
+		jobBuilder.registerJob(job1);
+		jobBuilder.registerJob(job2);
+
+		JobConfig job1Config = JobConfig.builder().name("j1").build();
+		JobConfig job2Config = JobConfig.builder().name("j2").build();
+
+		Date oneSecondFromNow = Date.from(Instant.now().plusMillis(1000));
+
+		scheduler.schedule(job1Config, oneSecondFromNow);
+		scheduler.schedule(job2Config, oneSecondFromNow);
+		scheduler.start();
+
+		latch1.await(4, SECONDS);
+		latch2.await(4, SECONDS);
+		scheduler.pause();
+	}
+
+	@Test
+	public void scheduleWithJobConfigAndCronWorks() throws InterruptedException {
+		Job job1 = job("j1", latch1);
+		Job job2 = job("j2", latch2);
+
+		jobBuilder.registerJob(job1);
+		jobBuilder.registerJob(job2);
+
+		JobConfig job1Config = JobConfig.builder().name("j1").build();
+		JobConfig job2Config = JobConfig.builder().name("j2").build();
+
+		scheduler.schedule(job1Config, TRIGGER_EVERY_SECOND);
+		scheduler.schedule(job2Config, TRIGGER_EVERY_SECOND);
+		scheduler.start();
+
+		latch1.await(4, SECONDS);
+		latch2.await(4, SECONDS);
+		scheduler.pause();
+	}
+
+	private Job job(String jobName, CountDownLatch latch) {
+		return scheduler.jobs().get(jobName).incrementer(new RunIdIncrementer()) // adds unique parameter on each run so
+																					// that createJob can be rerun
+				.start(scheduler.steps().get("step").tasklet((contribution, chunkContext) -> {
+					latch.countDown();
+					return RepeatStatus.FINISHED;
+				}).allowStartIfComplete(true).build()).build();
+	}
 }

--- a/util/src/test/resources/application.properties
+++ b/util/src/test/resources/application.properties
@@ -1,1 +1,2 @@
 spring.batch.job.enabled=false
+server.port=9090


### PR DESCRIPTION
Summary:

- Added overloaded methods to AdHocScheduler to not pass in a Job reference, but rather a JobConfig. This is advantageous for jobs defined as Beans that consist of steps that dynamically pass in job parameters that must be constructed via "spring magic" at the time of running the job, similar to how the AdHocStarter works (uses JobConfig's jobName to find the job). Autowiring the job to get a reference to pass in to the AdHocScheduler breaks an application where steps have been defined as beans with dynamic parameters. Eg: https://docs.spring.io/spring-batch/docs/current/reference/html/step.html#job-scope
- Added the ability to pass job parameters to a scheduled job! JobDetail doesn't do the trick for scheduled jobs, but luckily this library can. 
- Added increased timeouts to some of the tests due to intermittent failures. 

Issues:
- Not sure how to write integration tests for the new scheduler methods as the lookup of the job happens with the jobLocator based on the bean name of the job, and requires the jobName to match the bean name, or the job having been registered with a different name prior to making the call. 

Future Implementation:
- JobConfig may not be the right object to pass in, as the async flag doesn't really apply. Other than that it's a good fit. If a different construct were to be created it would need the ability to specify dynamic trigger creation - I.E. run once at specified date, or with cron schedule, and be extensible to add more scheduling options as the TriggerBuilder has more options and may add more someday? A new construct may also be able to use the @Builder notation and default to a group if unspecified. 

Existing Issues:
- The scheduler uses a group called "group", which seems to result in two scheduler pools being created, one is the default and the other is the one specified in the AdHocScheduler. It may be worth changing the default GROUP_NAME to reference Quartz's default group at some stage. 

